### PR TITLE
调试工具：文件服务器&&代理服务器

### DIFF
--- a/frontend/out/server.js
+++ b/frontend/out/server.js
@@ -1,0 +1,45 @@
+var fs   = require("fs"  );
+var http = require("http");
+var url  = require("url" );
+var path = require("path");
+var sendRequest = require("request");
+
+var root = path.resolve(".");
+var allowExternalRequest = true;
+var address = "static.cnbetacdn.com";
+
+http.createServer(function(request,response){
+    if(!allowExternalRequest&&request.headers["host"]!="127.0.0.1:8080"&&request.headers["host"]!="localhost:8080"){
+        response.writeHead(403);
+        response.end("<h1>403 Forbidden</h1>")
+        return;
+    }
+    
+    console.log("-------------------------------------");
+    console.log(request.method+":"+url.parse(request.url).pathname);
+    console.log(url.parse(request.url,true).query);
+    console.log("user-agent:"+request.headers["user-agent"]);
+
+    var fpath = path.join(root, url.parse(request.url).pathname);
+    fs.stat(fpath,function(err, stat){
+        if(fpath == root+"/"){
+            console.log("status: 200");
+            response.writeHead(200,{"Content-type":"text/html; charset=utf-8"});
+            fs.createReadStream("index.html").pipe(response);
+        }
+        else if(err||!stat.isFile()){
+            //TODO
+            var target = "http://" + address + url.parse(request.url).pathname;
+            console.log(target);
+            sendRequest(target).pipe(response);
+        }
+        else{
+            console.log("status: 200");
+            response.writeHead(200);
+            fs.readFile(fpath,"utf-8",function(err,data){
+                var rsp = data ;
+                response.end(rsp);
+            })
+        }
+    });    
+}).listen(8080, ()=>{console.log("listen on 8080");});


### PR DESCRIPTION
在/frontend/out/下增加了server.js
功能：1.运行后可以通过浏览器访问本地文件；2.将一些请求转发到远程服务器，从而实现远程调试
使用方法：1.修改第9行内容为远程服务器地址；2.命令行运行`node server.js`(需安装nodejs)
已知问题：对于一些特殊的文件会有问题(如：字体)

无冲突
